### PR TITLE
Add support for custom events of other plugins

### DIFF
--- a/client.js
+++ b/client.js
@@ -3,11 +3,19 @@
 	var socketId = multiplex.id;
 	var socket = io.connect(multiplex.url);
 
-	socket.on(multiplex.id, function(data) {
+	socket.on(multiplex.id, function(message) {
 		// ignore data from sockets that aren't ours
-		if (data.socketId !== socketId) { return; }
+		if (message.socketId !== socketId) { return; }
 		if( window.location.host === 'localhost:1947' ) return;
 
-		Reveal.setState(data.state);
+		if ( message.state ) {
+			Reveal.setState(message.state);
+		}
+		if ( message.content ) {
+			// forward custom events to other plugins
+			var event = new CustomEvent('received');
+			event.content = message.content;
+			document.dispatchEvent( event );
+		}
 	});
 }());

--- a/master.js
+++ b/master.js
@@ -7,12 +7,13 @@
 
 	var socket = io.connect( multiplex.url );
 
-	function post() {
+	function post( evt ) {
 
 		var messageData = {
 			state: Reveal.getState(),
 			secret: multiplex.secret,
-			socketId: multiplex.id
+			socketId: multiplex.id,
+			content: (evt || {}).content
 		};
 
 		socket.emit( 'multiplex-statechanged', messageData );
@@ -30,5 +31,6 @@
 	Reveal.on( 'overviewshown', post );
 	Reveal.on( 'paused', post );
 	Reveal.on( 'resumed', post );
+	document.addEventListener( 'send', post ); // broadcast custom events sent by other plugins
 
 }());


### PR DESCRIPTION
Hi Hakim,

this is a small PR allowing to use multiplex for custom synchronisations for other plugins. For example, it can be used for the chalkboard plugin to broadcast drawings to the client. It would be great if you could merge the PR :-)

